### PR TITLE
options for table parameters and subfolders

### DIFF
--- a/uvot-download/download_heasarc.py
+++ b/uvot-download/download_heasarc.py
@@ -35,7 +35,10 @@ def download_heasarc(heasarc_files):
                 os.remove(i)
             continue
 
-        #run browse_extract with all of the parameters needed to make data.dat
+        # extract the columns that were saved
+        table_cols = [col.strip() for col in rows_list[1].split('|') if (col != '' and col != '\n')]
+        # the last one is always '_offset', which we don't care about
+        table_cols = table_cols[0:-1]
 
         #important inputs for loadtxt:
         #comments: comments out last line that lists number of observations returned for an object
@@ -44,7 +47,8 @@ def download_heasarc(heasarc_files):
         #obslist = np.loadtxt(filename, dtype = 'str', delimiter = '|',
         #                         comments = 'S', skiprows = 2, usecols = (1,2)).tolist()
         obslist = np.loadtxt(filename, dtype = 'str', delimiter = '|',
-                                 skiprows=3, comments='B', usecols = (1,2)).tolist()
+                                 skiprows=3, comments='B',
+                                 usecols = tuple(np.arange(0,len(table_cols))+1) ).tolist()
         id_list = list()
 
         #if obslist is empty:
@@ -65,7 +69,7 @@ def download_heasarc(heasarc_files):
             
 
         #condition that handles cases where HEASARC query returns only one row or zero rows
-        if len(obslist[0]) > 2:
+        if type(obslist[0]) == str:
             #print(obslist)
             obsid = obslist[0]
             starttime = obslist[1]
@@ -80,10 +84,9 @@ def download_heasarc(heasarc_files):
             with open(download_file, 'a') as download_scr:
                 download_scr.write(wget_uvot + '\n')
                 download_scr.write(wget_auxil + '\n')
-                #download_scr.write('mv '+obsid+' '+obj+'/ \n')
             
         elif len(obslist[0]) == 0:
-            print("* Search of table swiftmastr around "+obj+" with a radius 5' returns 0 rows")
+            print("* Search of table swiftmastr around "+gal_name+" returns 0 rows.")
             print("* Looks like there's no observation data for this object.")
             print("* Check to make sure that this object has been observed. Moving on...")
             continue
@@ -91,7 +94,8 @@ def download_heasarc(heasarc_files):
         else:
             for i in range(len(obslist)):
                 #print(obslist[i])
-                [obsid, starttime] = obslist[i]
+                obsid = obslist[i][table_cols.index('obsid')]
+                starttime = obslist[i][table_cols.index('start_time')]
         
                 start_month = starttime[0:7]
                 start_month = start_month.replace('-','_')
@@ -104,7 +108,6 @@ def download_heasarc(heasarc_files):
                 with open(download_file, 'a') as download_scr:
                     download_scr.write(wget_uvot + '\n')
                     download_scr.write(wget_auxil + '\n')
-                    #download_scr.write('mv '+obsid+' '+obj+'/ \n')
 
         #run the download script here and put the results in the directories created at the beginning of the list
 

--- a/uvot-download/download_heasarc.py
+++ b/uvot-download/download_heasarc.py
@@ -21,7 +21,7 @@ def download_heasarc(heasarc_files):
     for filename in heasarc_files:
 
         # galaxy name
-        gal_name = filename.split('/')[-2]
+        gal_name = os.path.realpath(filename).split('/')[-2]
     
         # read in the query output
         with open(filename, 'r') as fh:
@@ -50,12 +50,14 @@ def download_heasarc(heasarc_files):
         #if obslist is empty:
         #    continue to next obj in obj_list, though if there's nothing that comes next, will it just end the program?
 
-        # prefix for all of the wget commands
+        # path where things will get saved
         save_path = '/'.join( os.path.realpath(filename).split('/')[:-1] )
+
+        # prefix for all of the wget commands
         wget_prefix = "wget -q -nH --no-check-certificate --cut-dirs=5 -r -l0 -c -N -np -R 'index*' -erobots=off --directory-prefix="+save_path+" --retr-symlinks https://heasarc.gsfc.nasa.gov/FTP/swift/data/obs/"
 
         # path+name for download file
-        download_file = os.path.dirname(filename) + '/download.scr'
+        download_file = save_path + '/download.scr'
         
         # make sure download script doesn't exist
         if os.path.isfile(download_file):

--- a/uvot-download/query_heasarc.py
+++ b/uvot-download/query_heasarc.py
@@ -7,7 +7,7 @@ import urllib.request
 import pdb
 
 def query_heasarc(input_obj, list_opt=None, search_radius=7.0,
-                      create_folder=True):
+                      create_folder=True, table_params=['obsid','start_time']):
     """
     Find observations of a target in HEASARC
 
@@ -26,6 +26,12 @@ def query_heasarc(input_obj, list_opt=None, search_radius=7.0,
         choose whether to create a sub-folder for the object(s) or save the
         table into the current directory
 
+    table_params : list of strings (default=['obsid','start_time'])
+        List of parameters to extract from the observing information.  The
+        default params will be included in all queries.  More info (including
+        allowed params) here:
+        https://heasarc.gsfc.nasa.gov/W3Browse/swift/swiftmastr.html
+
     """
 
     #condition that handles either a list of entries from a file that needs to be loaded or a single object put into a list
@@ -34,6 +40,13 @@ def query_heasarc(input_obj, list_opt=None, search_radius=7.0,
         #print('expect a list and do list things')
     else:
         obj_list = [input_obj]
+
+    # ensure 'obsid' and 'start_time' are in table_params
+    if 'obsid' not in table_params:
+        table_params.append('obsid')
+    if 'start_time' not in table_params:
+        table_params.append('start_time')
+    
     
     for obj in obj_list:
 
@@ -61,7 +74,7 @@ def query_heasarc(input_obj, list_opt=None, search_radius=7.0,
               '&Radius='+str(search_radius) + \
               '&NR=SIMBAD' + \
               '&GIFsize=0' + \
-              '&Fields=&varon='+'&varon='.join(['obsid','start_time']) + \
+              '&Fields=&varon='+'&varon='.join(table_params) + \
               '&Entry='+urllib.request.quote(obj) + \
               '&displaymode=BatchDisplay' + \
               "' > " + output_file

--- a/uvot-download/query_heasarc.py
+++ b/uvot-download/query_heasarc.py
@@ -6,9 +6,10 @@ import urllib.request
 
 import pdb
 
-def query_heasarc(input_obj, list_opt=None, search_radius=7.0):
+def query_heasarc(input_obj, list_opt=None, search_radius=7.0,
+                      create_folder=True):
     """
-    Find observations of a target in HEASARC, create download script, and download the data
+    Find observations of a target in HEASARC
 
     Parameters
     ----------
@@ -20,6 +21,10 @@ def query_heasarc(input_obj, list_opt=None, search_radius=7.0):
 
     search_radius : float (default=7.0)
         Search radius (arcmin)
+
+    create_folder : boolean (default=True)
+        choose whether to create a sub-folder for the object(s) or save the
+        table into the current directory
 
     """
 
@@ -33,11 +38,15 @@ def query_heasarc(input_obj, list_opt=None, search_radius=7.0):
     for obj in obj_list:
 
         #make new folders for each of the objects
-        if not os.path.exists(obj):
-            os.mkdir(obj)
+        if create_folder:
+            if not os.path.exists(obj):
+                os.mkdir(obj)
 
         # file name to save the table
-        output_file = obj + '/heasarc_obs.dat'
+        if create_folder:
+            output_file = obj + '/heasarc_obs.dat'
+        else:
+            output_file = obj+'_heasarc_obs.dat'
 
         # command to generate HEASARC query
         #cmd = 'browse_extract_wget.pl table=swiftmastr position=' \


### PR DESCRIPTION
Two changes:
* optional input (`table_params`) for query_heasarc.py: will query for any list of table parameters (adds `obsid` and `start_time` if they're not included), and download_heasarc.py is updated to determine which parameters are present
* additional input (`create_folder`) for query_heasarc.py: if set to True (default), it will create a sub-folder for the galaxy, and put all files there; otherwise, will put all files into the current directory
