### PR TITLE
assorted updates and new input keywords

### DIFF
--- a/uvot-download/query_heasarc.py
+++ b/uvot-download/query_heasarc.py
@@ -7,7 +7,8 @@ import urllib.request
 import pdb
 
 def query_heasarc(input_obj, list_opt=False, search_radius=7.0,
-                      create_folder=True, table_params=['obsid','start_time']):
+                      create_folder=True,
+                      table_params=['obsid','start_time','uvot_expo_w2','uvot_expo_m2','uvot_expo_w1']):
     """
     Find observations of a target in HEASARC
 
@@ -44,12 +45,10 @@ def query_heasarc(input_obj, list_opt=False, search_radius=7.0,
         if type(input_obj) == list:
             obj_list = input_obj
 
-    # ensure 'obsid' and 'start_time' are in table_params
-    if 'obsid' not in table_params:
-        table_params.append('obsid')
-    if 'start_time' not in table_params:
-        table_params.append('start_time')
-    
+    # ensure defaults are in table_params
+    for col in ['obsid','start_time','uvot_expo_w2','uvot_expo_m2','uvot_expo_w1']:
+        if col not in table_params:
+            table_params.append(col)    
     
     for obj in obj_list:
 


### PR DESCRIPTION
Changes are:
* `query_heasarc.py`
  - the exposure time in the UV filters is included in the search results table
  - added new optional keyword `display_table`: if `True`, the table of observations will be displayed on the terminal, rather than saved to a file (useful for quick checks of observations)
* `download_heasarc.py`
  - I figured out how to get astropy tables to read in the search results table, which makes the subsequent code a lot simpler/cleaner
  - added new optional keyword `download_filters`, in the case where you only want to download the UVOT data if certain filters are present
  - added new optional keyword `min_exp`, which sets a minimum exposure time (for at least one filter) in order to download the data - useful for the case where an object has been observed a gazillion times (like M81), but you don't want to deal with downloading every single observation
